### PR TITLE
fix: add types field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "type": "git",
     "url": "git+https://github.com/multiformats/js-murmur3.git"
   },
+  "types": "types/index.d.ts",
   "typesVersions": {
     "*": {
       "*": [


### PR DESCRIPTION
Adds missing field so types can be loaded.