### PR TITLE
feat!: implement sync multihash hasher and export encode methods (#17) (#18)

### DIFF
--- a/deps.js
+++ b/deps.js
@@ -1,0 +1,3 @@
+// @ts-nocheck - this will be overlayed
+import mur from 'murmurhash3js-revisited'
+export { mur }

--- a/deps.ts
+++ b/deps.ts
@@ -1,0 +1,10 @@
+interface Mur {
+  x86: {
+    hash32(input:Uint8Array): number
+  }
+  x64: {
+    hash128(input:Uint8Array): string
+  }
+}
+
+export var mur:Mur

--- a/index.js
+++ b/index.js
@@ -1,29 +1,9 @@
-import { from } from 'multiformats/hashes/hasher'
-import { bytes } from 'multiformats'
-// @ts-ignore
-import mur from 'murmurhash3js-revisited'
 
-/**
- * @param {number} number
- * @returns {Uint8Array}
- */
-function fromNumberTo32BitBuf (number) {
-  const bytes = new Array(4)
-  for (let i = 0; i < 4; i++) {
-    bytes[i] = number & 0xff
-    number = number >> 8
-  }
-  return new Uint8Array(bytes)
-}
+import * as mur32 from './murmur32.js'
+import * as mur128 from './murmur128.js'
 
-export const murmur332 = from({
-  name: 'murmur3-32',
-  code: 0x23,
-  encode: (input) => fromNumberTo32BitBuf(mur.x86.hash32(input))
-})
+/** @type {import('multiformats/hashes/interface').SyncMultihashHasher<0x23>} */
+export const murmur332 = mur32
 
-export const murmur3128 = from({
-  name: 'murmur3-128',
-  code: 0x22,
-  encode: (input) => bytes.fromHex(mur.x64.hash128(input))
-})
+/** @type {import('multiformats/hashes/interface').SyncMultihashHasher<0x22>} */
+export const murmur3128 = mur128

--- a/murmur128.js
+++ b/murmur128.js
@@ -1,0 +1,21 @@
+import { mur } from './deps.js'
+import { bytes } from 'multiformats'
+import * as Digest from 'multiformats/hashes/digest'
+
+export const name = 'murmur3-128'
+export const code = 0x22
+
+/**
+ * @param {Uint8Array} input
+ * @returns {import('multiformats/hashes/interface').MultihashDigest<typeof code>}
+ */
+export const digest = (input) => {
+  return Digest.create(code, encode(input))
+}
+
+/**
+ * @param {Uint8Array} input
+ */
+export const encode = (input) => {
+  return bytes.fromHex(mur.x64.hash128(input))
+}

--- a/murmur32.js
+++ b/murmur32.js
@@ -1,0 +1,31 @@
+import { mur } from './deps.js'
+import * as Digest from 'multiformats/hashes/digest'
+
+export const name = 'murmur3-32'
+export const code = 0x23
+
+/**
+ * @param {Uint8Array} input
+ * @returns {import('multiformats/hashes/interface').MultihashDigest<typeof code>}
+ */
+export const digest = (input) => {
+  return Digest.create(code, encode(input))
+}
+
+/**
+ * @param {Uint8Array} input
+ */
+export const encode = (input) => fromNumberTo32BitBuf(mur.x86.hash32(input))
+
+/**
+ * @param {number} number
+ * @returns {Uint8Array}
+ */
+const fromNumberTo32BitBuf = (number) => {
+  const bytes = new Array(4)
+  for (let i = 0; i < 4; i++) {
+    bytes[i] = number & 0xff
+    number = number >> 8
+  }
+  return new Uint8Array(bytes)
+}

--- a/package.json
+++ b/package.json
@@ -31,10 +31,18 @@
   "author": "Mikeal Rogers <mikeal.rogers@gmail.com> (https://www.mikealrogers.com/)",
   "license": "(Apache-2.0 AND MIT)",
   "exports": {
-    "import": "./index.js"
+    ".": {
+      "import": "./index.js"
+    },
+    "./murmur32.js": {
+      "import": "./murmur32.js"
+    },
+    "./murmur128.js": {
+      "import": "./murmur128.js"
+    }
   },
   "dependencies": {
-    "multiformats": "^9.5.4",
+    "multiformats": "^9.6.0",
     "murmurhash3js-revisited": "^3.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
PR to release sync API as a breaking change

- encode method in main module is gone, but still available when
  importing specic implementation e.g. '@multiformats/murmur3/murmur128'