### PR TITLE
feat: expose murmur3-64

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,12 @@ The `murmur3-128`, multicodec code `0x22`, may be imported as:
 import { murmur3128 } from '@multiformats/murmur3'
 ```
 
+The `murmur3-x64-64` (which is first 64-bits of `murmur3-128` used in UnixFS directory sharding), multicodec code `0x22`, may be imported as:
+
+```js
+import { murmur364 } from '@multiformats/murmur3'
+```
+
 ## License
 
 Licensed under either of

--- a/src/index.js
+++ b/src/index.js
@@ -27,3 +27,9 @@ export const murmur3128 = from({
   code: 0x22,
   encode: (input) => bytes.fromHex(mur.x64.hash128(input))
 })
+
+export const murmur364 = from({
+  name: 'murmur3-x64-64',
+  code: 0x22,
+  encode: (input) => bytes.fromHex(mur.x64.hash128(input)).subarray(0, 8)
+})

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ export const murmur3128 = from({
   encode: (input) => bytes.fromHex(mur.x64.hash128(input))
 })
 
+// A special-use 0x22 that truncates 64 bits, specifically for use in the UnixFS HAMT
 export const murmur364 = from({
   name: 'murmur3-x64-64',
   code: 0x22,

--- a/test/test-basics.spec.js
+++ b/test/test-basics.spec.js
@@ -1,7 +1,7 @@
 /* eslint-env mocha */
 import * as murmur3 from '../src/index.js'
 import { assert } from 'aegir/chai'
-import { bytes } from 'multiformats'
+import { bytes, varint } from 'multiformats'
 
 const fixtures = [
   ['murmur3-32', 'beep boop', '2304243ddb9e'],
@@ -28,6 +28,11 @@ describe('Hashers', () => {
     assert.strictEqual(murmur3.murmur332.code, 0x23)
     assert.strictEqual(hash.code, murmur3.murmur332.code)
     assert.strictEqual(bytes.toHex(hash.bytes), '2304e7285ca1')
+
+    const [code, offset] = varint.decode(hash.bytes)
+    assert.equal(code, murmur3.murmur332.code)
+    const [size] = varint.decode(hash.bytes, offset)
+    assert.equal(size, 32 / 8)
   })
 
   it('murmur3-128', async () => {
@@ -35,5 +40,24 @@ describe('Hashers', () => {
     assert.strictEqual(murmur3.murmur3128.code, 0x22)
     assert.strictEqual(hash.code, murmur3.murmur3128.code)
     assert.strictEqual(bytes.toHex(hash.bytes), '2210df48782b0b497325f116d6589ef4c112')
+
+    const [code, offset] = varint.decode(hash.bytes)
+    assert.equal(code, murmur3.murmur3128.code)
+    const [size] = varint.decode(hash.bytes, offset)
+    assert.equal(size, 128 / 8)
+  })
+  it('murmur3-64', async () => {
+    const hash = await murmur3.murmur364.digest(fixture)
+    assert.strictEqual(murmur3.murmur364.code, 0x22)
+    assert.strictEqual(hash.code, murmur3.murmur364.code)
+    assert.deepEqual(
+      [...(await murmur3.murmur3128.encode(fixture)).slice(0, 8)],
+      [...await murmur3.murmur364.encode(fixture)]
+    )
+
+    const [code, offset] = varint.decode(hash.bytes)
+    assert.equal(code, murmur3.murmur364.code)
+    const [size] = varint.decode(hash.bytes, offset)
+    assert.equal(size, 64 / 8)
   })
 })


### PR DESCRIPTION
According to the multicodec table

> The first 64-bits of a murmur3-x64-128 - used for UnixFS directory sharding.


In js-unixfs we slice of first 64 bits manually. This simply exports another codec that does that out of the box